### PR TITLE
Implement JSL component property injection.

### DIFF
--- a/example/weather/app/application.go
+++ b/example/weather/app/application.go
@@ -3,7 +3,6 @@ package app
 import (
 	"context"
 	"database/sql"
-	"fmt"
 	"time"
 
 	config "sample/pkg/batch/config"
@@ -21,8 +20,6 @@ import (
 	// weather 関連のパッケージをインポート
 	appJob "sample/example/weather/job"
 	appTasklet "sample/example/weather/step/tasklet" // 新しい tasklet パッケージをインポート
-	appConfig "sample/example/weather/config"
-	appRepo "sample/example/weather/repository"
 	weatherprocessor "sample/example/weather/step/processor" // パッケージ名を変更
 	weatherreader "sample/example/weather/step/reader"       // パッケージ名を変更
 	weatherwriter "sample/example/weather/step/writer"       // パッケージ名を変更
@@ -36,47 +33,43 @@ import (
 // registerApplicationComponents はアプリケーション固有のコンポーネントとジョブを JobFactory に登録します。
 func registerApplicationComponents(jobFactory *factory.JobFactory, cfg *config.Config, db *sql.DB) {
 	// Weather 関連コンポーネントの登録
-	jobFactory.RegisterComponentBuilder("weatherItemReader", func(cfg *config.Config, db *sql.DB) (any, error) { // Renamed component name
-		weatherReaderCfg := &appConfig.WeatherReaderConfig{
-			APIEndpoint: cfg.Batch.APIEndpoint,
-			APIKey:      cfg.Batch.APIKey,
-		}
-		return weatherreader.NewWeatherReader(weatherReaderCfg), nil // パッケージ名を変更
+	jobFactory.RegisterComponentBuilder("weatherItemReader", func(cfg *config.Config, db *sql.DB, properties map[string]string) (any, error) { // Renamed component name
+		// NewWeatherReader のシグネチャ変更に合わせて引数を渡す
+		return weatherreader.NewWeatherReader(cfg, db, properties) // ★ 変更
 	})
-	jobFactory.RegisterComponentBuilder("weatherItemProcessor", func(cfg *config.Config, db *sql.DB) (any, error) { // Renamed component name
-		return weatherprocessor.NewWeatherProcessor(), nil // パッケージ名を変更
+	jobFactory.RegisterComponentBuilder("weatherItemProcessor", func(cfg *config.Config, db *sql.DB, properties map[string]string) (any, error) { // Renamed component name
+		// NewWeatherProcessor のシグネチャ変更に合わせて引数を渡す
+		return weatherprocessor.NewWeatherProcessor(cfg, db, properties) // ★ 変更
 	})
-	jobFactory.RegisterComponentBuilder("weatherItemWriter", func(cfg *config.Config, db *sql.DB) (any, error) { // Renamed component name
-		var weatherSpecificRepo appRepo.WeatherRepository
-		switch cfg.Database.Type {
-		case "postgres", "redshift":
-			weatherSpecificRepo = appRepo.NewPostgresWeatherRepository(db)
-		case "mysql":
-			weatherSpecificRepo = appRepo.NewMySQLWeatherRepository(db)
-		default:
-			return nil, fmt.Errorf("未対応のデータベースタイプです: %s", cfg.Database.Type)
-		}
-		return weatherwriter.NewWeatherWriter(weatherSpecificRepo), nil // パッケージ名を変更
+	jobFactory.RegisterComponentBuilder("weatherItemWriter", func(cfg *config.Config, db *sql.DB, properties map[string]string) (any, error) { // Renamed component name
+		// NewWeatherWriter のシグネチャ変更に合わせて引数を渡す
+		return weatherwriter.NewWeatherWriter(cfg, db, properties) // ★ 変更
 	})
 
 	// ダミーコンポーネントの登録
-	jobFactory.RegisterComponentBuilder("dummyItemReader", func(cfg *config.Config, db *sql.DB) (any, error) { // Renamed component name
-		return weatherreader.NewDummyReader(), nil // パッケージ名を変更
+	jobFactory.RegisterComponentBuilder("dummyItemReader", func(cfg *config.Config, db *sql.DB, properties map[string]string) (any, error) { // Renamed component name
+		// NewDummyReader のシグネチャ変更に合わせて引数を渡す
+		return weatherreader.NewDummyReader(cfg, db, properties) // ★ 変更
 	})
-	jobFactory.RegisterComponentBuilder("dummyItemProcessor", func(cfg *config.Config, db *sql.DB) (any, error) { // Renamed component name
-		return weatherprocessor.NewDummyProcessor(), nil // パッケージ名を変更
+	jobFactory.RegisterComponentBuilder("dummyItemProcessor", func(cfg *config.Config, db *sql.DB, properties map[string]string) (any, error) { // Renamed component name
+		// NewDummyProcessor のシグネチャ変更に合わせて引数を渡す
+		return weatherprocessor.NewDummyProcessor(cfg, db, properties) // ★ 変更
 	})
-	jobFactory.RegisterComponentBuilder("dummyItemWriter", func(cfg *config.Config, db *sql.DB) (any, error) { // Renamed component name
-		return weatherwriter.NewDummyWriter(), nil // パッケージ名を変更
+	jobFactory.RegisterComponentBuilder("dummyItemWriter", func(cfg *config.Config, db *sql.DB, properties map[string]string) (any, error) { // Renamed component name
+		// NewDummyWriter のシグネチャ変更に合わせて引数を渡す
+		return weatherwriter.NewDummyWriter(cfg, db, properties) // ★ 変更
 	})
-	jobFactory.RegisterComponentBuilder("executionContextItemReader", func(cfg *config.Config, db *sql.DB) (any, error) { // Renamed component name
-		return executionContextItemReader.NewExecutionContextReader(), nil
+	jobFactory.RegisterComponentBuilder("executionContextItemReader", func(cfg *config.Config, db *sql.DB, properties map[string]string) (any, error) { // Renamed component name
+		// NewExecutionContextReader のシグネチャ変更に合わせて引数を渡す
+		return executionContextItemReader.NewExecutionContextReader(cfg, db, properties) // ★ 変更
 	})
-	jobFactory.RegisterComponentBuilder("executionContextItemWriter", func(cfg *config.Config, db *sql.DB) (any, error) { // Renamed component name
-		return executionContextItemWriter.NewExecutionContextWriter(), nil
+	jobFactory.RegisterComponentBuilder("executionContextItemWriter", func(cfg *config.Config, db *sql.DB, properties map[string]string) (any, error) { // Renamed component name
+		// NewExecutionContextWriter のシグネチャ変更に合わせて引数を渡す
+		return executionContextItemWriter.NewExecutionContextWriter(cfg, db, properties) // ★ 変更
 	})
-	jobFactory.RegisterComponentBuilder("dummyTasklet", func(cfg *config.Config, db *sql.DB) (any, error) {
-		return appTasklet.NewDummyTasklet(), nil // appTasklet パッケージから呼び出す
+	jobFactory.RegisterComponentBuilder("dummyTasklet", func(cfg *config.Config, db *sql.DB, properties map[string]string) (any, error) {
+		// NewDummyTasklet のシグネチャ変更に合わせて引数を渡す
+		return appTasklet.NewDummyTasklet(cfg, db, properties) // ★ 変更
 	})
 
 	// Step-level listeners の登録

--- a/example/weather/step/processor/dummy_processor.go
+++ b/example/weather/step/processor/dummy_processor.go
@@ -2,10 +2,13 @@ package weatherprocessor // パッケージ名を 'weatherprocessor' に変更
 
 import (
 	"context"
+	"database/sql" // Add sql import for *sql.DB
+	"fmt"          // Add fmt for Sprintf
+	"time"
+
+	config "sample/pkg/batch/config" // config パッケージをインポート
 	itemprocessor "sample/pkg/batch/step/processor" // Renamed import
 	logger "sample/pkg/batch/util/logger"
-	"fmt" // Add fmt for Sprintf
-	"time"
 )
 
 // DummyProcessor は入力アイテムをそのまま返すダミーの Processor です。
@@ -13,7 +16,13 @@ import (
 type DummyProcessor struct{}
 
 // NewDummyProcessor は新しい DummyProcessor のインスタンスを作成します。
-func NewDummyProcessor() *DummyProcessor { return &DummyProcessor{} }
+// ComponentBuilder のシグネチャに合わせ、cfg, db, properties を受け取りますが、現時点では利用しません。
+func NewDummyProcessor(cfg *config.Config, db *sql.DB, properties map[string]string) (*DummyProcessor, error) { // ★ 変更: シグネチャを factory.ComponentBuilder に合わせる
+	_ = cfg        // 未使用の引数を無視
+	_ = db
+	_ = properties
+	return &DummyProcessor{}, nil
+}
 
 // Process は ItemProcessor インターフェースの実装です。
 // 入力として受け取ったアイテムをそのまま返すか、汎用的なダミーデータを返します。

--- a/example/weather/step/processor/weather_processor.go
+++ b/example/weather/step/processor/weather_processor.go
@@ -2,9 +2,11 @@ package weatherprocessor // パッケージ名を 'weatherprocessor' に変更
 
 import (
 	"context"
+	"database/sql" // Add sql import for *sql.DB
 	"fmt"
 	"time"
 
+	config "sample/pkg/batch/config" // config パッケージをインポート
 	itemprocessor "sample/pkg/batch/step/processor" // Renamed import
 	"sample/pkg/batch/util/exception" // exception パッケージをインポート
 
@@ -29,12 +31,15 @@ type WeatherProcessor struct {
 	// config *config.WeatherProcessorConfig // 必要に応じて追加
 }
 
-// NewWeatherProcessor が引数なし、または WeatherProcessorConfig を受け取るように修正 (ここでは引数なしのまま)
-func NewWeatherProcessor(/* cfg *config.WeatherProcessorConfig */) *WeatherProcessor {
+// NewWeatherProcessor が ComponentBuilder のシグネチャに合わせるように修正
+func NewWeatherProcessor(cfg *config.Config, db *sql.DB, properties map[string]string) (*WeatherProcessor, error) { // ★ 変更: シグネチャを factory.ComponentBuilder に合わせる
+	_ = cfg        // 未使用の引数を無視
+	_ = db
+	_ = properties
 	return &WeatherProcessor{
 		// 初期化
 		// config: cfg, // 必要に応じて初期化
-	}
+	}, nil
 }
 
 // Process メソッドが Processor[*entity.OpenMeteoForecast, []*entity.WeatherDataToStore] インターフェースを満たすように修正

--- a/example/weather/step/reader/dummy_reader.go
+++ b/example/weather/step/reader/dummy_reader.go
@@ -1,79 +1,85 @@
 package weatherreader // パッケージ名を 'weatherreader' に変更
 
 import (
-  "context"
-  "io" // io パッケージをインポート
+	"context"
+	"database/sql" // Add sql import for *sql.DB
+	"io"           // io パッケージをインポート
 
-  core "sample/pkg/batch/job/core" // core パッケージをインポート
-  logger "sample/pkg/batch/util/logger" // logger パッケージをインポート
-  itemreader "sample/pkg/batch/step/reader" // ItemReader インターフェースをインポート
+	config "sample/pkg/batch/config" // config パッケージをインポート
+	core "sample/pkg/batch/job/core" // core パッケージをインポート
+	itemreader "sample/pkg/batch/step/reader" // ItemReader インターフェースをインポート
+	logger "sample/pkg/batch/util/logger" // logger パッケージをインポート
 )
 
 // DummyReader は常に io.EOF を返すダミーの Reader です。
 // ItemReader[any] インターフェースを実装します。
-type DummyReader struct{ // 構造体名は変更しない
-  // ExecutionContext を保持するためのフィールド
-  executionContext core.ExecutionContext
+type DummyReader struct { // 構造体名は変更しない
+	// ExecutionContext を保持するためのフィールド
+	executionContext core.ExecutionContext
 }
 
 // NewDummyReader は新しい DummyReader のインスタンスを作成します。
-func NewDummyReader() *DummyReader {
-  return &DummyReader{
-    executionContext: core.NewExecutionContext(), // 初期化
-  }
+// ComponentBuilder のシグネチャに合わせ、cfg, db, properties を受け取りますが、現時点では利用しません。
+func NewDummyReader(cfg *config.Config, db *sql.DB, properties map[string]string) (*DummyReader, error) { // ★ 変更: シグネチャを factory.ComponentBuilder に合わせる
+	_ = cfg        // 未使用の引数を無視
+	_ = db
+	_ = properties
+	return &DummyReader{
+		executionContext: core.NewExecutionContext(), // 初期化
+	}, nil
 }
 
 // Read は ItemReader インターフェースの実装です。
 // 常に io.EOF を返してデータの終端を示します。
 func (r *DummyReader) Read(ctx context.Context) (any, error) { // O は any
-  // Context の完了をチェック
-  select {
-  case <-ctx.Done():
-    return nil, ctx.Err()
-  default:
-  }
-  logger.Debugf("DummyReader.Read が呼び出されました。io.EOF を返します。")
-  return nil, io.EOF // 常に終端を示す
+	// Context の完了をチェック
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	default:
+	}
+	logger.Debugf("DummyReader.Read が呼び出されました。io.EOF を返します。")
+	return nil, io.EOF // 常に終端を示す
 }
 
 // Close は ItemReader インターフェースの実装です。
 // DummyReader は閉じるリソースがないため、何もしません。
 func (r *DummyReader) Close(ctx context.Context) error {
-  // Context の完了をチェック
-  select {
-  case <-ctx.Done():
-    return ctx.Err()
-  default:
-  }
-  logger.Debugf("DummyReader.Close が呼び出されました。")
-  return nil
+	// Context の完了をチェック
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+	}
+	logger.Debugf("DummyReader.Close が呼び出されました。")
+	return nil
 }
 
 // SetExecutionContext は ItemReader インターフェースの実装です。
 // 渡された ExecutionContext を内部に設定します。
 func (r *DummyReader) SetExecutionContext(ctx context.Context, ec core.ExecutionContext) error {
-  // Context の完了をチェック
-  select {
-  case <-ctx.Done():
-    return ctx.Err()
-  default:
-  }
-  r.executionContext = ec
-  logger.Debugf("DummyReader.SetExecutionContext が呼び出されました。")
-  return nil
+	// Context の完了をチェック
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+	}
+	r.executionContext = ec
+	logger.Debugf("DummyReader.SetExecutionContext が呼び出されました。")
+	return nil
 }
 
 // GetExecutionContext は ItemReader インターフェースの実装です。
 // 現在の ExecutionContext を返します。
 func (r *DummyReader) GetExecutionContext(ctx context.Context) (core.ExecutionContext, error) {
-  // Context の完了をチェック
-  select {
-  case <-ctx.Done():
-    return nil, ctx.Err()
-  default:
-  }
-  logger.Debugf("DummyReader.GetExecutionContext が呼び出されました。")
-  return r.executionContext, nil
+	// Context の完了をチェック
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	default:
+	}
+	logger.Debugf("DummyReader.GetExecutionContext が呼び出されました。")
+	return r.executionContext, nil
 }
 
 // DummyReader が ItemReader[any] インターフェースを満たすことを確認

--- a/example/weather/step/tasklet/dummy_tasklet.go
+++ b/example/weather/step/tasklet/dummy_tasklet.go
@@ -2,10 +2,12 @@ package tasklet
 
 import (
 	"context"
+	"database/sql" // Add sql import for *sql.DB
 	"fmt"
 	"math/rand" // rand パッケージをインポート
 	"time"
 
+	config "sample/pkg/batch/config" // config パッケージをインポート
 	core "sample/pkg/batch/job/core"
 	step "sample/pkg/batch/step" // pkg/batch/step を参照
 	logger "sample/pkg/batch/util/logger"
@@ -21,11 +23,15 @@ type DummyTasklet struct {
 }
 
 // NewDummyTasklet は新しい DummyTasklet のインスタンスを作成します。
-func NewDummyTasklet() *DummyTasklet {
+// ComponentBuilder のシグネチャに合わせ、cfg, db, properties を受け取りますが、現時点では利用しません。
+func NewDummyTasklet(cfg *config.Config, db *sql.DB, properties map[string]string) (*DummyTasklet, error) { // ★ 変更: シグネチャを factory.ComponentBuilder に合わせる
+	_ = cfg        // 未使用の引数を無視
+	_ = db
+	_ = properties
 	return &DummyTasklet{
 		executionContext: core.NewExecutionContext(),
 		executionCount:   0,
-	}
+	}, nil
 }
 
 // Execute は Tasklet のビジネスロジックを実行します。

--- a/example/weather/step/writer/dummy_writer.go
+++ b/example/weather/step/writer/dummy_writer.go
@@ -3,24 +3,29 @@ package weatherwriter // パッケージ名を 'weatherwriter' に変更
 import (
 	"context"
 	"database/sql" // sql パッケージをインポート
+
+	config "sample/pkg/batch/config" // config パッケージをインポート
+	core "sample/pkg/batch/job/core"
 	itemwriter "sample/pkg/batch/step/writer" // Renamed import
 	logger "sample/pkg/batch/util/logger"
-
-	core "sample/pkg/batch/job/core"
 )
 
 // DummyWriter は何も行わないダミーの Writer です。
 // ItemWriter[any] インターフェースを実装します。
-type DummyWriter struct{ // 構造体名は変更しない
+type DummyWriter struct { // 構造体名は変更しない
 	// ExecutionContext を保持するためのフィールド
 	executionContext core.ExecutionContext
 }
 
 // NewDummyWriter は新しい DummyWriter のインスタンスを作成します。
-func NewDummyWriter() *DummyWriter {
+// ComponentBuilder のシグネチャに合わせ、cfg, db, properties を受け取りますが、現時点では利用しません。
+func NewDummyWriter(cfg *config.Config, db *sql.DB, properties map[string]string) (*DummyWriter, error) { // ★ 変更: シグネチャを factory.ComponentBuilder に合わせる
+	_ = cfg        // 未使用の引数を無視
+	_ = db
+	_ = properties
 	return &DummyWriter{
 		executionContext: core.NewExecutionContext(), // 初期化
-	}
+	}, nil
 }
 
 // Write は ItemWriter インターフェースの実装です。

--- a/pkg/batch/job/component/builder.go
+++ b/pkg/batch/job/component/builder.go
@@ -1,0 +1,11 @@
+package component
+
+import (
+	"database/sql"
+	config "sample/pkg/batch/config"
+)
+
+// ComponentBuilder は、特定のコンポーネント（Reader, Processor, Writer, Tasklet）を生成するための関数型です。
+// 依存関係 (config, db, properties など) を受け取り、生成されたコンポーネントのインターフェースとエラーを返します。
+// ジェネリックインターフェースを返すため、any を使用します。
+type ComponentBuilder func(cfg *config.Config, db *sql.DB, properties map[string]string) (any, error)

--- a/pkg/batch/job/jsl/model.go
+++ b/pkg/batch/job/jsl/model.go
@@ -40,7 +40,8 @@ type Step struct {
 
 // ComponentRef refers to a registered component (reader, processor, writer, tasklet).
 type ComponentRef struct {
-	Ref string `yaml:"ref"` // The name/ID of the component (e.g., "weatherReader", "myTasklet")
+	Ref        string            `yaml:"ref"`                 // The name/ID of the component (e.g., "weatherReader", "myTasklet")
+	Properties map[string]string `yaml:"properties,omitempty"` // JSLから注入されるプロパティ
 }
 
 // Chunk defines chunk-oriented processing properties for a step.

--- a/pkg/batch/step/writer/execution_context_writer.go
+++ b/pkg/batch/step/writer/execution_context_writer.go
@@ -1,12 +1,11 @@
-// pkg/batch/step/writer/execution_context_writer.go
 package itemwriter // パッケージ名を 'itemwriter' に変更
 
 import (
 	"context"
 	"database/sql" // トランザクションを受け取るため
 
+	config "sample/pkg/batch/config" // config パッケージをインポート
 	core "sample/pkg/batch/job/core"
-	// itemwriter "sample/pkg/batch/step/writer" // REMOVED: Self-import is not needed
 	logger "sample/pkg/batch/util/logger"
 )
 
@@ -20,12 +19,23 @@ type ExecutionContextWriter struct {
 }
 
 // NewExecutionContextWriter は新しい ExecutionContextWriter のインスタンスを作成します。
-// 書き込むデータのキーを指定します。
-func NewExecutionContextWriter() *ExecutionContextWriter {
-	return &ExecutionContextWriter{
+// ComponentBuilder のシグネチャに合わせ、cfg, db, properties を受け取ります。
+// properties から dataKey を設定します。
+func NewExecutionContextWriter(cfg *config.Config, db *sql.DB, properties map[string]string) (*ExecutionContextWriter, error) { // ★ 変更: シグネチャを factory.ComponentBuilder に合わせる
+	_ = cfg // 未使用の引数を無視
+	_ = db
+
+	writer := &ExecutionContextWriter{
 		dataKey:          "processed_weather_data", // デフォルトのキー。JSLで設定可能にするべき。
 		executionContext: core.NewExecutionContext(),
 	}
+
+	// properties から dataKey を設定
+	if key, ok := properties["dataKey"]; ok && key != "" {
+		writer.dataKey = key
+	}
+
+	return writer, nil
 }
 
 // Write はアイテムのチャンクを JobExecution.ExecutionContext に保存します。


### PR DESCRIPTION
## Overview

- JSLを介したコンポーネントプロパティ注入メカニズムを実装
- 関連するコンパイルエラーを修正
- JSLでコンポーネントの設定を外部化できるようになった

## Implementation Details.

- JSLの ComponentRef に properties フィールドを追加
- ComponentBuilder のシグネチャを properties を受け取るように変更
- JSL フロー変換ロジックを修正し properties をコンポーネントビルダに渡すようにした
- アプリケーションコンポーネントの登録と NewXxx 関数のシグネチャを更新
- WeatherReader が JSL の properties から API エンドポイントと API キーを読み込むように実装
- インポートサイクル解消のため ComponentBuilder を共通パッケージに移動
- validateTransition 関数の戻り値型エラーを修正
- 未使用インポートの整理