### PR TITLE
Implement batch artifact lifecycle methods.

### DIFF
--- a/example/weather/step/reader/dummy_reader.go
+++ b/example/weather/step/reader/dummy_reader.go
@@ -29,6 +29,18 @@ func NewDummyReader(cfg *config.Config, db *sql.DB, properties map[string]string
 	}, nil
 }
 
+// Open は ItemReader インターフェースの実装です。
+// DummyReader はリソースを開く必要がないため、SetExecutionContext を呼び出すだけです。
+func (r *DummyReader) Open(ctx context.Context, ec core.ExecutionContext) error { // ★ 追加
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+	}
+	logger.Debugf("DummyReader.Open が呼び出されました。")
+	return r.SetExecutionContext(ctx, ec)
+}
+
 // Read は ItemReader インターフェースの実装です。
 // 常に io.EOF を返してデータの終端を示します。
 func (r *DummyReader) Read(ctx context.Context) (any, error) { // O は any

--- a/example/weather/step/reader/weather_reader.go
+++ b/example/weather/step/reader/weather_reader.go
@@ -55,6 +55,19 @@ func NewWeatherReader(cfg *config.Config, db *sql.DB, properties map[string]stri
 	}, nil
 }
 
+// Open は ItemReader インターフェースの実装です。
+// ExecutionContext から状態を復元し、必要に応じてリソースを開きます。
+func (r *WeatherReader) Open(ctx context.Context, ec core.ExecutionContext) error { // ★ 追加
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+	}
+	logger.Debugf("WeatherReader.Open が呼び出されました。")
+	// SetExecutionContext と同様のロジックで状態を復元
+	return r.SetExecutionContext(ctx, ec)
+}
+
 // Read メソッドが Reader インターフェースを満たすように修正
 // アイテムを一つずつ返すように変更
 func (r *WeatherReader) Read(ctx context.Context) (any, error) { // 戻り値を any に変更

--- a/example/weather/step/writer/dummy_writer.go
+++ b/example/weather/step/writer/dummy_writer.go
@@ -28,6 +28,18 @@ func NewDummyWriter(cfg *config.Config, db *sql.DB, properties map[string]string
 	}, nil
 }
 
+// Open は ItemWriter インターフェースの実装です。
+// DummyWriter はリソースを開く必要がないため、SetExecutionContext を呼び出すだけです。
+func (w *DummyWriter) Open(ctx context.Context, ec core.ExecutionContext) error { // ★ 追加
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+	}
+	logger.Debugf("DummyWriter.Open が呼び出されました。")
+	return w.SetExecutionContext(ctx, ec)
+}
+
 // Write は ItemWriter インターフェースの実装です。
 // アイテムのスライスを受け取り、何も行わずに nil を返します。
 func (w *DummyWriter) Write(ctx context.Context, tx *sql.Tx, items []any) error { // ★ シグネチャを []any に変更し、tx を追加

--- a/example/weather/step/writer/weather_writer.go
+++ b/example/weather/step/writer/weather_writer.go
@@ -43,6 +43,18 @@ func NewWeatherWriter(cfg *config.Config, db *sql.DB, properties map[string]stri
 	}, nil
 }
 
+// Open は ItemWriter インターフェースの実装です。
+// WeatherItemWriter はリソースを開く必要がないため、SetExecutionContext を呼び出すだけです。
+func (w *WeatherItemWriter) Open(ctx context.Context, ec core.ExecutionContext) error { // ★ 追加
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+	}
+	logger.Debugf("WeatherItemWriter.Open が呼び出されました。")
+	return w.SetExecutionContext(ctx, ec)
+}
+
 // Write は加工済みの天気データアイテムのチャンクをデータベースに保存します。
 // 引数を []weather_entity.WeatherDataToStore に変更し、トランザクションを受け取るように変更します。
 func (w *WeatherItemWriter) Write(ctx context.Context, tx *sql.Tx, items []any) error {

--- a/pkg/batch/step/processor/item_processor.go
+++ b/pkg/batch/step/processor/item_processor.go
@@ -1,9 +1,12 @@
 package itemprocessor // パッケージ名を 'itemprocessor' に変更
 
 import "context"
+import core "sample/pkg/batch/job/core" // core パッケージをインポート
 
 // ItemProcessor はアイテムを処理するステップのインターフェースです。
 // I は入力アイテムの型、O は出力アイテムの型です。
 type ItemProcessor[I, O any] interface {
   Process(ctx context.Context, item I) (O, error) // 処理対象のアイテムと結果を I, O 型で扱う
+  SetExecutionContext(ctx context.Context, ec core.ExecutionContext) error // ★ 追加: ExecutionContext を設定
+  GetExecutionContext(ctx context.Context) (core.ExecutionContext, error) // ★ 追加: ExecutionContext を取得
 }

--- a/pkg/batch/step/reader/execution_context_reader.go
+++ b/pkg/batch/step/reader/execution_context_reader.go
@@ -48,6 +48,18 @@ func NewExecutionContextReader(cfg *config.Config, db *sql.DB, properties map[st
 	return reader, nil
 }
 
+// Open は ItemReader インターフェースの実装です。
+// ExecutionContext から状態を復元し、必要に応じてリソースを開きます。
+func (r *ExecutionContextReader) Open(ctx context.Context, ec core.ExecutionContext) error { // ★ 追加
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+	}
+	// SetExecutionContext と同様のロジックで状態を復元
+	return r.SetExecutionContext(ctx, ec)
+}
+
 // Read は ExecutionContext からアイテムを一つずつ読み込みます。
 func (r *ExecutionContextReader) Read(ctx context.Context) (any, error) {
 	select {

--- a/pkg/batch/step/reader/item_reader.go
+++ b/pkg/batch/step/reader/item_reader.go
@@ -6,6 +6,7 @@ import core "sample/pkg/batch/job/core" // core パッケージをインポー�
 // ItemReader はデータを読み込むステップのインターフェースです。
 // O は読み込まれるアイテムの型です。
 type ItemReader[O any] interface {
+  Open(ctx context.Context, ec core.ExecutionContext) error // ★ 追加: リソースを開き、ExecutionContextから状態を復元
   Read(ctx context.Context) (O, error) // 読み込んだデータを O 型で返す
   Close(ctx context.Context) error // リソースを解放するためのメソッド
   SetExecutionContext(ctx context.Context, ec core.ExecutionContext) error // ExecutionContext を設定

--- a/pkg/batch/step/writer/execution_context_writer.go
+++ b/pkg/batch/step/writer/execution_context_writer.go
@@ -38,6 +38,18 @@ func NewExecutionContextWriter(cfg *config.Config, db *sql.DB, properties map[st
 	return writer, nil
 }
 
+// Open は ItemWriter インターフェースの実装です。
+// ExecutionContext から状態を復元し、必要に応じてリソースを開きます。
+func (w *ExecutionContextWriter) Open(ctx context.Context, ec core.ExecutionContext) error { // ★ 追加
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	default:
+	}
+	// SetExecutionContext と同様のロジックで状態を復元
+	return w.SetExecutionContext(ctx, ec)
+}
+
 // Write はアイテムのチャンクを JobExecution.ExecutionContext に保存します。
 // この Writer はデータベーストランザクションを直接使用しないため、tx は無視されます。
 func (w *ExecutionContextWriter) Write(ctx context.Context, tx *sql.Tx, items []any) error { // tx を追加

--- a/pkg/batch/step/writer/item_writer.go
+++ b/pkg/batch/step/writer/item_writer.go
@@ -7,6 +7,7 @@ import core "sample/pkg/batch/job/core" // core パッケージをインポー�
 // ItemWriter はデータを書き込むステップのインターフェースです。
 // I は書き込まれるアイテムの型です。
 type ItemWriter[I any] interface {
+  Open(ctx context.Context, ec core.ExecutionContext) error // ★ 追加: リソースを開き、ExecutionContextから状態を復元
   Write(ctx context.Context, tx *sql.Tx, items []I) error // 書き込むデータを I 型のスライスで扱い、トランザクションを受け取る
   Close(ctx context.Context) error // リソースを解放するためのメソッド
   SetExecutionContext(ctx context.Context, ec core.ExecutionContext) error // ExecutionContext を設定


### PR DESCRIPTION
## Overview

- JSR352準拠のためバッチアーティファクトのライフサイクルメソッドを強化
- Reader Writer ProcessorインターフェースにOpen SetExecutionContext GetExecutionContextメソッドを追加
- 各コンポーネントがこれらのライフサイクルメソッドを実装

## Implementation Details.

- ItemReader ItemWriterインターフェースに Open メソッドを追加
- ItemProcessorインターフェースに SetExecutionContext GetExecutionContext メソッドを追加
- WeatherReader DummyReader ExecutionContextReader に Open メソッドを実装
- WeatherProcessor DummyProcessor に SetExecutionContext GetExecutionContext メソッドを実装
- WeatherWriter DummyWriter ExecutionContextWriter に Open メソッドを実装
- これにより再開可能性の基盤を強化